### PR TITLE
API-4363: Call correct TPA Endpoint

### DIFF
--- a/app/uk/gov/hmrc/apiplatformjobs/connectors/ThirdPartyApplicationConnector.scala
+++ b/app/uk/gov/hmrc/apiplatformjobs/connectors/ThirdPartyApplicationConnector.scala
@@ -67,8 +67,8 @@ abstract class ThirdPartyApplicationConnector(implicit val ec: ExecutionContext)
     implicit val hc: HeaderCarrier = HeaderCarrier()
 
     http.GET[PaginatedApplicationLastUseResponse](
-      url = s"$serviceBaseUrl/application",
-      queryParams = Seq("lastUseBefore" -> urlEncode(ISODateFormatter.withZoneUTC().print(lastUseDate))))
+      url = s"$serviceBaseUrl/applications",
+      queryParams = Seq("lastUseBefore" -> ISODateFormatter.withZoneUTC().print(lastUseDate)))
       .map(page => toDomain(page.applications))
   }
 
@@ -104,8 +104,8 @@ object ThirdPartyApplicationConnector {
   private[connectors] case class PaginatedApplicationLastUseResponse(applications: List[ApplicationLastUseDate],
                                                                      page: Int,
                                                                      pageSize: Int,
-                                                                     total: Int,
-                                                                     matching: Int)
+                                                                     totalNumberOfApplications: Int,
+                                                                     numberOfMatchingApplications: Int)
 
   case class ThirdPartyApplicationConnectorConfig(
     applicationSandboxBaseUrl: String, applicationSandboxUseProxy: Boolean, applicationSandboxBearerToken: String, applicationSandboxApiKey: String,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -171,13 +171,13 @@ UnusedApplications {
 
 UpdateUnusedApplicationRecordsJob {
   SANDBOX {
-    startTime = "00:30"
+    startTime = "00:30" # Time is in UTC
     executionInterval = 1d
     enabled = false
   }
 
   PRODUCTION {
-    startTime = "01:00"
+    startTime = "01:00" # Time is in UTC
     executionInterval = 1d
     enabled = false
   }
@@ -185,13 +185,13 @@ UpdateUnusedApplicationRecordsJob {
 
 DeleteUnusedApplicationsJob {
   SANDBOX {
-    startTime = "01:30"
+    startTime = "01:30" # Time is in UTC
     executionInterval = 1d
     enabled = false
   }
 
   PRODUCTION {
-    startTime = "02:00"
+    startTime = "02:00" # Time is in UTC
     executionInterval = 1d
     enabled = false
   }

--- a/test/uk/gov/hmrc/apiplatformjobs/connectors/ThirdPartyApplicationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/apiplatformjobs/connectors/ThirdPartyApplicationConnectorSpec.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.apiplatformjobs.connectors
 
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import org.joda.time.DateTime
@@ -26,8 +24,7 @@ import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.http.Status
-import play.api.http.Status.{OK, NO_CONTENT, BAD_REQUEST}
+import play.api.http.Status.{BAD_REQUEST, NO_CONTENT, OK}
 import uk.gov.hmrc.apiplatformjobs.connectors.ThirdPartyApplicationConnector.{ApplicationLastUseDate, ApplicationResponse, Collaborator, PaginatedApplicationLastUseResponse}
 import uk.gov.hmrc.apiplatformjobs.models.ApplicationUsageDetails
 import uk.gov.hmrc.http._
@@ -133,7 +130,8 @@ class ThirdPartyApplicationConnectorSpec extends UnitSpec with ScalaFutures with
 
     "return application details as ApplicationUsageDetails objects" in new Setup {
       val lastUseDate = DateTime.now.minusMonths(12)
-      val encodedDateString: String = URLEncoder.encode(dateFormatter.withZoneUTC().print(lastUseDate), StandardCharsets.UTF_8.toString)
+      val dateString: String = dateFormatter.withZoneUTC().print(lastUseDate)
+
       val oldApplication1Admin: String = "foo@bar.com"
       val oldApplication1 =
         ApplicationLastUseDate(
@@ -152,8 +150,8 @@ class ThirdPartyApplicationConnectorSpec extends UnitSpec with ScalaFutures with
           Some(DateTime.now.minusMonths(14)))
 
       when(mockHttpClient.GET[PaginatedApplicationLastUseResponse](
-        meq( s"$baseUrl/application"),
-        meq(Seq("lastUseBefore" -> encodedDateString)))(any(), any(), any()))
+        meq( s"$baseUrl/applications"),
+        meq(Seq("lastUseBefore" -> dateString)))(any(), any(), any()))
         .thenReturn(successful(paginatedResponse(List(oldApplication1, oldApplication2))))
 
       val results = await(connector.applicationsLastUsedBefore(lastUseDate))
@@ -168,11 +166,11 @@ class ThirdPartyApplicationConnectorSpec extends UnitSpec with ScalaFutures with
 
     "return empty Sequence when no results are returned" in new Setup {
       val lastUseDate = DateTime.now.minusMonths(12)
-      val encodedDateString: String = URLEncoder.encode(dateFormatter.withZoneUTC().print(lastUseDate), StandardCharsets.UTF_8.toString)
+      val dateString: String = dateFormatter.withZoneUTC().print(lastUseDate)
 
       when(mockHttpClient.GET[PaginatedApplicationLastUseResponse](
-        meq( s"$baseUrl/application"),
-        meq(Seq("lastUseBefore" -> encodedDateString)))(any(), any(), any()))
+        meq( s"$baseUrl/applications"),
+        meq(Seq("lastUseBefore" -> dateString)))(any(), any(), any()))
         .thenReturn(successful(paginatedResponse(List.empty)))
 
       val results = await(connector.applicationsLastUsedBefore(lastUseDate))

--- a/test/uk/gov/hmrc/apiplatformjobs/scheduled/TimedJobSpec.scala
+++ b/test/uk/gov/hmrc/apiplatformjobs/scheduled/TimedJobSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apiplatformjobs.scheduled
+
+import com.typesafe.config.ConfigFactory
+import org.joda.time.{DateTime, DateTimeUtils, DateTimeZone, LocalTime}
+import org.mockito.ArgumentMatchersSugar
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import play.api.{Configuration, LoggerLike}
+import play.modules.reactivemongo.ReactiveMongoComponent
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TimedJobSpec extends PlaySpec with MockitoSugar with ArgumentMatchersSugar with MongoSpecSupport {
+
+  trait TestJobSetup {
+    val reactiveMongoComponent: ReactiveMongoComponent = new ReactiveMongoComponent {
+      override def mongoConnector: MongoConnector = mongoConnectorForTest
+    }
+    val mockLogger = mock[LoggerLike]
+
+    def testJob(startTime: String, executionInterval: String, enabled: Boolean = true) = {
+      val jobName = "TestJob"
+      val configuration =
+        new Configuration(
+          ConfigFactory.parseString(s"""
+          |$jobName {
+          |    startTime = "$startTime"
+          |    executionInterval = $executionInterval
+          |    enabled = $enabled
+          |  }""".stripMargin))
+
+      new TimedJob(jobName, configuration, reactiveMongoComponent, mockLogger) {
+        override def functionToExecute()(implicit executionContext: ExecutionContext): Future[RunningOfJobSuccessful] =
+          Future.successful(RunningOfJobSuccessful)
+      }
+    }
+  }
+
+  trait FixedTime {
+    val BaselineTime = DateTime.now.getMillis
+    DateTimeUtils.setCurrentMillisFixed(BaselineTime)
+  }
+
+  "calculateInitialDelay()" should {
+    "correctly calculate time until first run if time is later today" in new TestJobSetup with FixedTime {
+      val futureTime = LocalTime.now(DateTimeZone.UTC).plusHours(1).withSecondOfMinute(0).withMillisOfSecond(0)
+      val expectedDelay = futureTime.toDateTimeToday(DateTimeZone.UTC).getMillis - DateTime.now(DateTimeZone.UTC).getMillis
+
+      val jobToTest = testJob(futureTime.toString("HH:mm"), "1d")
+
+      jobToTest.initialDelay.toMillis must be (expectedDelay)
+    }
+
+    "correctly calculate time until first run if time is earlier today" in new TestJobSetup with FixedTime {
+      val pastTime = LocalTime.now(DateTimeZone.UTC).minusHours(1).withSecondOfMinute(0).withMillisOfSecond(0)
+      val expectedDelay = pastTime.toDateTimeToday(DateTimeZone.UTC).plusDays(1).getMillis - DateTime.now(DateTimeZone.UTC).getMillis
+
+      val jobToTest = testJob(pastTime.toString("HH:mm"), "1d")
+
+      jobToTest.initialDelay.toMillis must be (expectedDelay)
+    }
+  }
+}


### PR DESCRIPTION
TPA connector now calls `/applications` rather than `/application`